### PR TITLE
refactored Cover component CSS

### DIFF
--- a/src/components/Book/styles.js
+++ b/src/components/Book/styles.js
@@ -9,8 +9,8 @@ export const Cover = styled.img`
   filter: grayscale(100%);
   border: 2px solid #000;
   object-fit: cover;
-  aspect-ratio: 2 / 3;
   width: 100%;
+  height: 70%;
   margin-bottom: 16px;
 `
 


### PR DESCRIPTION
Since the `aspect-ratio` CSS property isn't compatible for all browsers yet, the book cover dimensions look wonky on Safari and iOS. We refactored the dimensions so that it now uses percentages for the width and height, to mimic the `aspect-ratio` functionality.

Source: https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio